### PR TITLE
[qml] CameraUI: read the correct viewfinder resolution from dconf

### DIFF
--- a/qml/pages/Settings.qml
+++ b/qml/pages/Settings.qml
@@ -5,6 +5,7 @@ import Nemo.Configuration 1.0
 Item {
     property alias global: globalSettings
     property alias mode: modeSettings
+    property alias jollaCamera: jollaCameraSettings
 
     ConfigurationGroup {
         id: globalSettings
@@ -25,6 +26,15 @@ Item {
             property string resolution: ""
             property int whiteBalance: CameraImageProcessing.WhiteBalanceAuto
         }
+    }
+
+    ConfigurationGroup {
+        id: jollaCameraSettings
+        path: "/apps/jolla-camera/" + globalSettings.cameraId + "/image"
+
+        property string viewfinderResolution
+        property string viewfinderResolution_16_9
+        property string viewfinderResolution_4_3
     }
 
     function strToSize(siz) {

--- a/src/resolutionmodel.cpp
+++ b/src/resolutionmodel.cpp
@@ -1,6 +1,6 @@
 #include "resolutionmodel.h"
 
-QSize sizeToRatio(const QSize &siz)
+QSize ResolutionModel::sizeToRatio(const QSize &siz) const
 {
     int a = siz.width();
     int b = siz.height();

--- a/src/resolutionmodel.h
+++ b/src/resolutionmodel.h
@@ -23,6 +23,7 @@ public:
     virtual int rowCount(const QModelIndex &parent) const;
     virtual QVariant data(const QModelIndex &index, int role) const;
 
+    Q_INVOKABLE QSize sizeToRatio(const QSize &siz) const;
     Q_INVOKABLE void setImageCapture(QObject *camera);
 
 private:


### PR DESCRIPTION
This PR allows to read the viewfinder resolution from the dconf configuration used by jolla-camera (which should be on every Sailfish HW adaptation).

In future it would be nice to adjust the actual size based on the aspect ratio, but for now this will do (and it's at least better than having the resolution hardcoded :smile: )

Tested successfully on Xperia X Compact and Jolla 1.