### PR TITLE
Focus circle tweaking

### DIFF
--- a/qml/pages/CameraUI.qml
+++ b/qml/pages/CameraUI.qml
@@ -221,7 +221,7 @@ Page {
         height: Theme.itemSizeMedium
         width: height
         radius: width / 2
-        border.width: 2
+        border.width: 4
         border.color: focusColor()
         color: "transparent"
         x: parent.width / 2

--- a/qml/pages/CameraUI.qml
+++ b/qml/pages/CameraUI.qml
@@ -435,11 +435,11 @@ Page {
 
     function focusColor() {
         if (camera.lockStatus == Camera.Unlocked) {
-            return Theme.primaryColor;
+            return "white";
         } else if (camera.lockStatus == Camera.Searching) {
-            return Theme.secondaryColor;
+            return "#e3e3e3" //light grey;
         } else {
-            return Theme.highlightColor;
+            return "lightgreen";
         }
     }
 

--- a/qml/pages/CameraUI.qml
+++ b/qml/pages/CameraUI.qml
@@ -132,6 +132,12 @@ Page {
                 animFlash.start();
                 _focusAndSnap = false;
             }
+            else if (camera.lockStatus == Camera.Locked) {
+                focusCircle.height = Theme.itemSizeSmall
+            }
+            else {
+                focusCircle.height = Theme.itemSizeMedium
+            }
         }
 
         onCameraStatusChanged: {

--- a/qml/pages/CameraUI.qml
+++ b/qml/pages/CameraUI.qml
@@ -132,12 +132,6 @@ Page {
                 animFlash.start();
                 _focusAndSnap = false;
             }
-            else if (camera.lockStatus == Camera.Locked) {
-                focusCircle.height = Theme.itemSizeSmall
-            }
-            else {
-                focusCircle.height = Theme.itemSizeMedium
-            }
         }
 
         onCameraStatusChanged: {
@@ -218,7 +212,7 @@ Page {
 
     Rectangle {
         id: focusCircle
-        height: Theme.itemSizeMedium
+        height: (camera.lockStatus == Camera.Locked) ? Theme.itemSizeSmall : Theme.itemSizeMedium
         width: height
         radius: width / 2
         border.width: 4

--- a/qml/pages/CameraUI.qml
+++ b/qml/pages/CameraUI.qml
@@ -435,11 +435,11 @@ Page {
 
     function focusColor() {
         if (camera.lockStatus == Camera.Unlocked) {
-            return Theme.highlightColor;
+            return Theme.primaryColor;
         } else if (camera.lockStatus == Camera.Searching) {
             return Theme.secondaryColor;
         } else {
-            return Theme.primaryColor;
+            return Theme.highlightColor;
         }
     }
 

--- a/qml/pages/CameraUI.qml
+++ b/qml/pages/CameraUI.qml
@@ -212,7 +212,7 @@ Page {
 
     Rectangle {
         id: focusCircle
-        height: Theme.itemSizeHuge
+        height: Theme.itemSizeMedium
         width: height
         radius: width / 2
         border.width: 2


### PR DESCRIPTION
In general focus circle is too big to pinpoint focussing and hard to read currently depending on the SFOS Ambience you use and colors set.  

In regards to visual helps settings unchangeable colors that are widely used in the camera industry to know what is in focus and what not helps focussing regardless of which Ambience is set in SFOS. 
This requires the focus circle to be a bit bigger and adding a nice effect on focus acquiring besides the color changing helps even more to indicate focus. 
