### PR TITLE
Implement manual focus mode.

### DIFF
--- a/harbour-advanced-camera.pro
+++ b/harbour-advanced-camera.pro
@@ -72,5 +72,4 @@ HEADERS += \
     src/fsoperations.h \
     src/resourcehandler.h
 
-PKGCONFIG += audioresource
 LIBS += -ldl

--- a/qml/pages/CameraUI.qml
+++ b/qml/pages/CameraUI.qml
@@ -17,6 +17,7 @@ Page {
     property bool _parametersLoaded: false
     property bool _recordingVideo: false
     property bool _setTempResolution: false
+    property bool _manualModeSelected: false
     readonly property int zoomStepSize: 5
     property int controlsRotation: 0
 
@@ -222,7 +223,7 @@ Page {
         icon.anchors.margins: Theme.paddingSmall
         onClicked: {
             if (camera.captureMode == Camera.CaptureStillImage) {
-                if (camera.focus.focusMode == Camera.FocusAuto || camera.focus.focusMode == Camera.FocusMacro || camera.focus.focusMode == Camera.FocusContinuous) {
+                if ((camera.focus.focusMode == Camera.FocusAuto && !_manualModeSelected) || camera.focus.focusMode == Camera.FocusMacro || camera.focus.focusMode == Camera.FocusContinuous) {
                     _focusAndSnap = true;
                     camera.searchAndLock();
                 } else {
@@ -358,19 +359,27 @@ Page {
     }
 
     function setFocusMode(focus) {
-        if (camera.focus.focusMode !== focus) {
+        if (focus === Camera.FocusManual) {
             camera.stop();
-            camera.focus.setFocusMode(focus);
+            camera.focus.setFocusMode(Camera.FocusAuto);
             camera.start();
-            settings.mode.focus = focus;
-
-            //Set the focus point pack to centre
-            focusCircle.x = page.width / 2;
-            focusCircle.y = page.height / 2;
-
-            camera.focus.focusPointMode = Camera.FocusPointAuto;
-            camera.searchAndLock();
+            _manualModeSelected = true;
+        } else {
+            _manualModeSelected = false;
+            if (camera.focus.focusMode !== focus) {
+                camera.stop();
+                camera.focus.setFocusMode(focus);
+                camera.start();
+            }
         }
+        settings.mode.focus = focus;
+
+        //Set the focus point back to centre
+        focusCircle.x = page.width / 2;
+        focusCircle.y = page.height / 2;
+
+        camera.focus.focusPointMode = Camera.FocusPointAuto;
+        camera.searchAndLock();
     }
 
     function getNearestViewFinderResolution() {

--- a/src/focusmodel.cpp
+++ b/src/focusmodel.cpp
@@ -49,6 +49,10 @@ void FocusModel::setCamera(QObject *camera)
                 m_focusModes[(QCameraFocus::FocusMode)c] = focusName((QCameraFocus::FocusMode)c);
             }
         }
+        //Add manual mode even if not supported as we simulate it
+        if (!m_focusModes.contains(QCameraFocus::ManualFocus)) {
+            m_focusModes[QCameraFocus::ManualFocus] = focusName(QCameraFocus::ManualFocus);
+        }
         endResetModel();
     }
 }


### PR DESCRIPTION
The camera, while claiming to support manual appears to ignore it.  This
sets a flag to indicate manual mode, and sets the real mode to auto.  If
the flag is set, dont focus when pressing the shutter.  Reest the flag
when the mode is changed.