### PR TITLE
Fix continuous focus

### DIFF
--- a/qml/pages/CameraUI.qml
+++ b/qml/pages/CameraUI.qml
@@ -558,6 +558,7 @@ Page {
                 camera.unlock()
             }
             camera.searchAndLock()
+            if (!_manualModeSelected) focusPointTimer.restart()
         }
     }
 
@@ -671,6 +672,18 @@ Page {
                  && camera.cameraStatus === Camera.UnloadedStatus
         onTriggered: {
             page._cameraReload = false
+        }
+    }
+
+    Timer {
+        id: focusPointTimer
+        interval: 7000
+        onTriggered: {
+            //Set the focus point back to centre
+            camera.focus.setFocusPointMode(Camera.FocusPointAuto)
+            // and unlock camera so AF is working again
+            camera.unlock()
+            if (camera.focus.focusMode === Camera.FocusAuto) camera.searchAndLock()
         }
     }
 

--- a/qml/pages/CameraUI.qml
+++ b/qml/pages/CameraUI.qml
@@ -555,6 +555,7 @@ Page {
 
                 camera.focus.focusPointMode = Camera.FocusPointCustom
                 camera.focus.setCustomFocusPoint(focusPoint)
+                camera.unlock()
             }
             camera.searchAndLock()
         }
@@ -740,11 +741,15 @@ Page {
                 camera.start()
             }
         }
+        camera.unlock() // Do not forget to unlock camera when changing focus mode
         settings.mode.focus = focus
 
-        //Set the focus point back to centre
-        camera.focus.setFocusPointMode(Camera.FocusPointAuto)
-        camera.searchAndLock()
+        // Do not lock focus when continuous focus is declared // TODO: We need to allow combination of continous with Auto + Macro
+        if (focus !== Camera.FocusContinuous || focus !== Camera.FocusManual) {
+            //Set the focus point back to centre
+            camera.focus.setFocusPointMode(Camera.FocusPointAuto)
+            camera.searchAndLock()
+        }
     }
 
     function getNearestViewFinderResolution() {
@@ -810,6 +815,12 @@ Page {
                             "video",
                             settings.global.storagePath) + "/VID_" + Qt.formatDateTime(
                             new Date(), "yyyyMMdd_hhmmss") + ".mp4"
+                if ((camera.focus.focusMode === Camera.FocusAuto
+                     && !_manualModeSelected)
+                        || camera.focus.focusMode === Camera.FocusMacro
+                        || camera.focus.focusMode === Camera.FocusContinuous) {
+                    camera.unlock()
+                }
                 camera.videoRecorder.record()
             }
         }

--- a/qml/pages/CameraUI.qml
+++ b/qml/pages/CameraUI.qml
@@ -801,12 +801,14 @@ Page {
                 _focusAndSnap = true
                 camera.searchAndLock()
             } else {
-                camera.imageCapture.captureToLocation(
-                            fsOperations.writableLocation(
-                                "image",
-                                settings.global.storagePath) + "/IMG_" + Qt.formatDateTime(
-                                new Date(), "yyyyMMdd_hhmmss") + ".jpg")
-                animFlash.start()
+                if (camera.lockStatus != Camera.Searching || camera.focus.focusMode === Camera.FocusManual) {
+                    camera.imageCapture.captureToLocation(
+                                fsOperations.writableLocation(
+                                    "image",
+                                    settings.global.storagePath) + "/IMG_" + Qt.formatDateTime(
+                                    new Date(), "yyyyMMdd_hhmmss") + ".jpg")
+                    animFlash.start()
+                }
             }
         } else {
             if (camera.videoRecorder.recorderStatus === CameraRecorder.RecordingStatus) {

--- a/qml/pages/CameraUI.qml
+++ b/qml/pages/CameraUI.qml
@@ -744,10 +744,11 @@ Page {
         camera.unlock() // Do not forget to unlock camera when changing focus mode
         settings.mode.focus = focus
 
+        //Set the focus point back to centre
+        camera.focus.setFocusPointMode(Camera.FocusPointAuto)
+
         // Do not lock focus when continuous focus is declared // TODO: We need to allow combination of continous with Auto + Macro
         if (focus !== Camera.FocusContinuous && focus !== Camera.FocusManual) {
-            //Set the focus point back to centre
-            camera.focus.setFocusPointMode(Camera.FocusPointAuto)
             camera.searchAndLock()
         }
     }

--- a/qml/pages/CameraUI.qml
+++ b/qml/pages/CameraUI.qml
@@ -745,7 +745,7 @@ Page {
         settings.mode.focus = focus
 
         // Do not lock focus when continuous focus is declared // TODO: We need to allow combination of continous with Auto + Macro
-        if (focus !== Camera.FocusContinuous || focus !== Camera.FocusManual) {
+        if (focus !== Camera.FocusContinuous && focus !== Camera.FocusManual) {
             //Set the focus point back to centre
             camera.focus.setFocusPointMode(Camera.FocusPointAuto)
             camera.searchAndLock()

--- a/qml/pages/Settings.qml
+++ b/qml/pages/Settings.qml
@@ -12,7 +12,7 @@ Item {
         id: globalSettings
         path: "/uk/co/piggz/harbour-advanced-camera"
         property int cameraCount: QtMultimedia.availableCameras.length
-        property string cameraId: QtMultimedia.availableCameras[0].deviceId
+        property string cameraId: "primary"
         property string captureMode: "image"
         property bool swapZoomControl: false
         property string gridMode: "none"

--- a/qml/pages/Settings.qml
+++ b/qml/pages/Settings.qml
@@ -12,7 +12,7 @@ Item {
         id: globalSettings
         path: "/uk/co/piggz/harbour-advanced-camera"
         property int cameraCount: QtMultimedia.availableCameras.length
-        property string cameraId: "primary"
+        property string cameraId: QtMultimedia.availableCameras[0]
         property string captureMode: "image"
         property bool swapZoomControl: false
         property string gridMode: "none"

--- a/qml/pages/Settings.qml
+++ b/qml/pages/Settings.qml
@@ -12,7 +12,7 @@ Item {
         id: globalSettings
         path: "/uk/co/piggz/harbour-advanced-camera"
         property int cameraCount: QtMultimedia.availableCameras.length
-        property string cameraId: QtMultimedia.availableCameras[0]
+        property string cameraId: QtMultimedia.availableCameras[0].deviceId
         property string captureMode: "image"
         property bool swapZoomControl: false
         property string gridMode: "none"

--- a/qml/pages/Settings.qml
+++ b/qml/pages/Settings.qml
@@ -27,7 +27,7 @@ Item {
             property int effect: CameraImageProcessing.ColorFilterNone
             property int exposure: Camera.ExposureManual
             property int flash: Camera.FlashOff
-            property int focus: CameraFocus.FocusAuto
+            property int focus: CameraFocus.FocusContinuous
             property int iso: 0
             property string resolution: ""
             property int whiteBalance: CameraImageProcessing.WhiteBalanceAuto

--- a/rpm/harbour-advanced-camera.spec
+++ b/rpm/harbour-advanced-camera.spec
@@ -13,7 +13,7 @@ Name:       harbour-advanced-camera
 %{!?qtc_make:%define qtc_make make}
 %{?qtc_builddir:%define _builddir %qtc_builddir}
 Summary:    Advanced camera
-Version:    0.7.0
+Version:    0.8.1
 Release:    1
 Group:      Qt/Qt
 License:    LICENSE


### PR DESCRIPTION
This fixes continuous focus not working at all. (unlock the camera more often)
Add a timer for manual focus point that hides itself after 7 seconds (same as Jolla Camera) in Auto and Continuous mode. 
Only shoot when focus is aquired in AF modes (avoid blurry images) - always shoot in manual focus mode
Make continuous mode default focus mode (like on every other camera app) 
