### PR TITLE
Camera setting fixes

### DIFF
--- a/qml/pages/CameraUI.qml
+++ b/qml/pages/CameraUI.qml
@@ -867,7 +867,7 @@ Page {
         if (supportedResolutions.length > 0) {
             //TODO find the best resolution for the correct aspect ratio
             //when we fix supportedViewfinderResolutions()
-            return supportedResolutions[0]
+            return Qt.size(supportedResolutions[0].width, supportedResolutions[0].height)
         }
 
         return Qt.size(Screen.height, Screen.width)

--- a/qml/pages/CameraUI.qml
+++ b/qml/pages/CameraUI.qml
@@ -803,23 +803,24 @@ Page {
     }
 
     function setFocusMode(focus) {
+        var requestedFocus = focus === Camera.FocusManual ? Camera.FocusAuto : focus
+        if (!camera.focus.isFocusModeSupported(requestedFocus)) {
+            console.log("focus mode " + focusStr(requestedFocus) +
+                        " is not supported, keeping " + focusStr(camera.focus.focusMode))
+            return
+        }
         console.log("setting focus mode " +
                     focusStr(camera.focus.focusMode) + " -> " + focusStr(focus))
 
         if (focus === Camera.FocusManual) {
-            if (camera.focus.focusMode !== Camera.FocusAuto) {
-                camera.stop()
-                camera.focus.setFocusMode(Camera.FocusAuto)
-                camera.start()
-            }
             _manualModeSelected = true
         } else {
             _manualModeSelected = false
-            if (camera.focus.focusMode !== focus) {
-                camera.stop()
-                camera.focus.setFocusMode(focus)
-                camera.start()
-            }
+        }
+        if (camera.focus.focusMode !== requestedFocus) {
+            camera.stop()
+            camera.focus.setFocusMode(requestedFocus)
+            camera.start()
         }
         camera.unlock() // Do not forget to unlock camera when changing focus mode
         settings.mode.focus = focus

--- a/qml/pages/CameraUI.qml
+++ b/qml/pages/CameraUI.qml
@@ -221,7 +221,7 @@ Page {
         }
 
         onCameraStatusChanged: {
-            console.log("Camera status:", cameraStatus)
+            console.log("Camera status:", cameraStatusStr())
 
             if (cameraStatus === Camera.StartingStatus) {
                 settingsOverlay.setCamera(camera)
@@ -734,10 +734,55 @@ Page {
         }
     }
 
+    function cameraStatusStr() {
+        switch(camera.cameraStatus){
+            case Camera.ActiveStatus:
+                return "Active"
+            case Camera.StartingStatus:
+                return "Starting"
+            case Camera.StoppingStatus:
+                return "Stopping"
+            case Camera.StandbyStatus:
+                return "Standby"
+            case Camera.LoadedStatus:
+                return "Loaded"
+            case Camera.LoadingStatus:
+                return "Loading"
+            case Camera.UnloadingStatus:
+                return "Unloading"
+            case Camera.UnloadedStatus:
+                return "Unloaded"
+            case Camera.UnavailableStatus:
+                return "Unavailable"
+            default:
+                return "unknown (" + camera.cameraStatus + ")"
+        }
+    }
+
+    function focusStr(focus) {
+        // TODO: It's possible to combine multiple Camera::FocusMode values, for example FocusMacro + FocusContinuous.
+        switch (focus) {
+            case CameraFocus.FocusManual:
+                return "Manual"
+            case CameraFocus.FocusHyperfocal:
+                return "Hyperfocal"
+            case CameraFocus.FocusInfinity:
+                return "Infinity"
+            case CameraFocus.FocusAuto:
+                return "Auto"
+            case CameraFocus.FocusContinuous:
+                return "Continuous"
+            case CameraFocus.FocusMacro:
+                return "Macro"
+            default:
+                return "unknown (" + focus + ")"
+        }
+    }
+
     function applySettings() {
         console.log("Applying settings in", settings.global.captureMode,
                     "mode for", camera.deviceId, "camera with status",
-                    camera.cameraStatus)
+                    cameraStatusStr())
 
         camera.imageProcessing.setColorFilter(settings.mode.effect)
         camera.exposure.setExposureMode(settings.mode.exposure)
@@ -758,6 +803,9 @@ Page {
     }
 
     function setFocusMode(focus) {
+        console.log("setting focus mode " +
+                    focusStr(camera.focus.focusMode) + " -> " + focusStr(focus))
+
         if (focus === Camera.FocusManual) {
             if (camera.focus.focusMode !== Camera.FocusAuto) {
                 camera.stop()


### PR DESCRIPTION
For fixing https://github.com/piggz/harbour-advanced-camera/issues/118 I resolved error `Cannot assign QJSValue to QSize` in `getNearestViewFinderResolution`. Resolution is setup to valid value with this fix, but application freeze in infinite loop then, when it is trying to setup unsupported focus mode. So I added check that focus mode is supported before setup it.