### PR TITLE
workaround PositionSource activation bug

### DIFF
--- a/qml/pages/CameraUI.qml
+++ b/qml/pages/CameraUI.qml
@@ -62,6 +62,20 @@ Page {
 
         active: settings.global.locationMetadata
 
+        onActiveChanged: {
+            // PositionSource is activated a moment after initialization
+            // regardless "active" property assignment. It looks like Qt bug.
+            // Code below workaround it.
+            console.log("positionSource.active: " + positionSource.active)
+            if (positionSource.active != settings.global.locationMetadata) {
+                if (settings.global.locationMetadata) {
+                    start();
+                } else {
+                    stop();
+                }
+            }
+        }
+
         updateInterval: 1000 // ms
     }
 


### PR DESCRIPTION
PositionSource is activated a moment after initialization
regardless "active" property assignment. It looks like Qt bug.
This change workaround it and stops the source when it should
be stopped and vice versa.

It is fixing https://github.com/piggz/harbour-advanced-camera/issues/117