### PR TITLE
setup required Sailjail permissions

### DIFF
--- a/harbour-advanced-camera.desktop
+++ b/harbour-advanced-camera.desktop
@@ -11,3 +11,8 @@ Name=Advanced Camera
 # a different app name in German locale (de).
 #Name[de]=harbour-advanced-camera
 Name[ru]=Улучшенная камера
+
+[X-Sailjail]
+Permissions=Audio;Location;RemovableMedia;Pictures;Videos
+OrganizationName=uk.co.piggz
+ApplicationName=AdvancedCamera

--- a/src/harbour-advanced-camera.cpp
+++ b/src/harbour-advanced-camera.cpp
@@ -37,6 +37,10 @@ int main(int argc, char *argv[])
 
     QGuiApplication *app = SailfishApp::application(argc, argv);
 
+    app->setOrganizationDomain("piggz.co.uk");
+    app->setOrganizationName("uk.co.piggz"); // needed for Sailjail
+    app->setApplicationName("AdvancedCamera");
+
     qmlRegisterType<EffectsModel>("uk.co.piggz.harbour_advanced_camera", 1, 0, "EffectsModel");
     qmlRegisterType<ExposureModel>("uk.co.piggz.harbour_advanced_camera", 1, 0, "ExposureModel");
     qmlRegisterType<IsoModel>("uk.co.piggz.harbour_advanced_camera", 1, 0, "IsoModel");


### PR DESCRIPTION
SFOS 4.4 enables Sailjail sandboxing for all applications by default.
Default permissions are pretty wide. It is better to request
just permissions that are really needed.